### PR TITLE
Move Trilha client into standalone application

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ docker run -p 8080:8080 s533-trilha-auditoria-servico:latest
 - `GET /api/actuator/health`: Verificação de saúde da aplicação
 - `GET /api/actuator/info`: Informações sobre a aplicação
 
+## Cliente de simulação
+
+Este repositório inclui o projeto [`trilha-auditoria-client`](trilha-auditoria-client/README.md), uma API Spring Boot separada (Java 21) que consome a Trilha Auditoria Serviço por REST. Ela pode ser executada de forma independente com `mvn spring-boot:run` dentro do diretório do cliente e expõe os endpoints `/api/v1/client/trilhas` para publicar e consultar trilhas na API original.
+
 
 
 Este projeto inclui um Jenkinsfile configurado para:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -88,3 +88,5 @@ spring.jpa.properties.hibernate.transaction.jta.platform=none
 #spring.jpa.properties.hibernate.generate_statistics=true
 spring.jpa.properties.hibernate.jdbc.batch_size=50
 spring.jpa.properties.hibernate.order_inserts=true
+
+# === Cliente Trilha API ===

--- a/trilha-auditoria-client/README.md
+++ b/trilha-auditoria-client/README.md
@@ -1,0 +1,16 @@
+# Trilha Auditoria Client
+
+Aplicação Spring Boot (Java 21) que expõe uma API REST para simular o consumo da Trilha Auditoria Serviço.
+
+## Como executar
+
+```bash
+mvn spring-boot:run
+```
+
+A porta padrão configurada é `9090`. O endpoint remoto pode ser ajustado pela propriedade `trilhaapi.client.base-url`.
+
+## Endpoints
+
+- `POST /api/v1/client/trilhas` — Encaminha uma trilha de auditoria para a API remota.
+- `GET /api/v1/client/trilhas` — Consulta trilhas de auditoria na API remota.

--- a/trilha-auditoria-client/pom.xml
+++ b/trilha-auditoria-client/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.4</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>br.gov.bnb.s533</groupId>
+    <artifactId>trilha-auditoria-client</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>trilha-auditoria-client</name>
+    <description>API cliente para consumir a Trilha Auditoria Serviço</description>
+
+    <properties>
+        <java.version>21</java.version>
+        <lombok.version>1.18.30</lombok.version>
+        <springdoc.version>2.8.6</springdoc.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/trilha-auditoria-client/src/main/java/br/gov/bnb/s533/client/TrilhaAuditoriaClientApplication.java
+++ b/trilha-auditoria-client/src/main/java/br/gov/bnb/s533/client/TrilhaAuditoriaClientApplication.java
@@ -1,0 +1,12 @@
+package br.gov.bnb.s533.client;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TrilhaAuditoriaClientApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(TrilhaAuditoriaClientApplication.class, args);
+    }
+}

--- a/trilha-auditoria-client/src/main/java/br/gov/bnb/s533/client/config/TrilhaApiClientConfig.java
+++ b/trilha-auditoria-client/src/main/java/br/gov/bnb/s533/client/config/TrilhaApiClientConfig.java
@@ -1,0 +1,28 @@
+package br.gov.bnb.s533.client.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class TrilhaApiClientConfig {
+
+    @Bean
+    public RestTemplate trilhaApiRestTemplate(
+            RestTemplateBuilder builder,
+            ObjectMapper objectMapper,
+            @Value("${trilhaapi.client.base-url}") String baseUrl
+    ) {
+        return builder
+                .additionalCustomizers(restTemplate -> restTemplate.getMessageConverters().stream()
+                        .filter(MappingJackson2HttpMessageConverter.class::isInstance)
+                        .map(MappingJackson2HttpMessageConverter.class::cast)
+                        .forEach(converter -> converter.setObjectMapper(objectMapper)))
+                .rootUri(baseUrl)
+                .build();
+    }
+}

--- a/trilha-auditoria-client/src/main/java/br/gov/bnb/s533/client/controller/TrilhaApiClientController.java
+++ b/trilha-auditoria-client/src/main/java/br/gov/bnb/s533/client/controller/TrilhaApiClientController.java
@@ -1,0 +1,75 @@
+package br.gov.bnb.s533.client.controller;
+
+import br.gov.bnb.s533.client.dto.ResultadoDTO;
+import br.gov.bnb.s533.client.dto.RetornoAuditoriaDTO;
+import br.gov.bnb.s533.client.dto.TrilhaDTO;
+import br.gov.bnb.s533.client.service.TrilhaApiClientService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/client/trilhas")
+@Validated
+@Tag(name = "Cliente Trilha de Auditoria", description = "Consome os endpoints expostos na Trilha API")
+@ApiResponses({
+        @ApiResponse(responseCode = "400", description = "Parâmetros inválidos", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "500", description = "Erro inesperado", content = @Content(schema = @Schema(hidden = true)))
+})
+public class TrilhaApiClientController {
+
+    private final TrilhaApiClientService trilhaApiClientService;
+
+    public TrilhaApiClientController(TrilhaApiClientService trilhaApiClientService) {
+        this.trilhaApiClientService = trilhaApiClientService;
+    }
+
+    @Operation(summary = "Encaminha uma trilha de auditoria para a API remota")
+    @PostMapping
+    public ResponseEntity<ResultadoDTO<TrilhaDTO>> enviarTrilha(@RequestBody @Valid TrilhaDTO trilhaDTO) {
+        ResponseEntity<ResultadoDTO<TrilhaDTO>> resposta = trilhaApiClientService.enviarTrilha(trilhaDTO);
+        HttpStatus status = resposta.getStatusCode();
+        return ResponseEntity.status(status).body(resposta.getBody());
+    }
+
+    @Operation(summary = "Consulta as trilhas de auditoria na API remota")
+    @GetMapping
+    public ResponseEntity<ResultadoDTO<List<RetornoAuditoriaDTO>>> consultarTrilhas(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dataInicio,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dataFim,
+            @RequestParam(required = false) String identidadeResponsavel,
+            @RequestParam(required = false) String identidadeSistema,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int limit,
+            @RequestParam(defaultValue = "0") @Min(0) int offset
+    ) {
+        ResponseEntity<ResultadoDTO<List<RetornoAuditoriaDTO>>> resposta = trilhaApiClientService.consultarTrilhas(
+                dataInicio,
+                dataFim,
+                identidadeResponsavel,
+                identidadeSistema,
+                limit,
+                offset
+        );
+        HttpStatus status = resposta.getStatusCode();
+        return ResponseEntity.status(status).body(resposta.getBody());
+    }
+}

--- a/trilha-auditoria-client/src/main/java/br/gov/bnb/s533/client/dto/ResultadoDTO.java
+++ b/trilha-auditoria-client/src/main/java/br/gov/bnb/s533/client/dto/ResultadoDTO.java
@@ -1,0 +1,23 @@
+package br.gov.bnb.s533.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ResultadoDTO<T> {
+
+    @Builder.Default
+    private int status = 200;
+
+    @Builder.Default
+    private String message = "Success";
+
+    private T data;
+}

--- a/trilha-auditoria-client/src/main/java/br/gov/bnb/s533/client/dto/RetornoAuditoriaDTO.java
+++ b/trilha-auditoria-client/src/main/java/br/gov/bnb/s533/client/dto/RetornoAuditoriaDTO.java
@@ -1,0 +1,19 @@
+package br.gov.bnb.s533.client.dto;
+
+import java.time.LocalDateTime;
+
+public record RetornoAuditoriaDTO(
+        Integer id,
+        LocalDateTime dataInicioEvento,
+        LocalDateTime dataFimEvento,
+        String identidadeResponsavel,
+        String identidadeSistema,
+        String identidadeModuloSistema,
+        String descricaoFuncionalidadeEvento,
+        String identidadeIpOrigem,
+        String identidadeHostOrigem,
+        String identidadeDominioOrigem,
+        Integer tipoEvento,
+        String descricaoTipoEvento
+) {
+}

--- a/trilha-auditoria-client/src/main/java/br/gov/bnb/s533/client/dto/TrilhaDTO.java
+++ b/trilha-auditoria-client/src/main/java/br/gov/bnb/s533/client/dto/TrilhaDTO.java
@@ -1,0 +1,44 @@
+package br.gov.bnb.s533.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TrilhaDTO {
+    @NotNull(message = "{identidadeTipoEvento.not.null}")
+    private Integer identidadeTipoEvento;
+    @NotNull(message = "{dataInicialEvento.not.null}")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    private LocalDateTime dataInicialEvento;
+    @NotNull(message = "{dataFinalEvento.not.null}")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    private LocalDateTime dataFinalEvento;
+    @Size(max = 50, message = "{identidadeResponsavel.size}")
+    private String identidadeResponsavel;
+    @Size(max = 5, message = "{identidadeSistema.size}")
+    private String identidadeSistema;
+    @Size(max = 20, message = "{identidadeModuloSistema.size}")
+    private String identidadeModuloSistema;
+    @Size(max = 32, message = "{descricaoFuncionalidadeEvento.size}")
+    private String descricaoFuncionalidadeEvento;
+    @Size(max = 15, message = "{identidadeIpOrigem.size}")
+    private String identidadeIpOrigem;
+    @Size(max = 32, message = "{identidadeHostOrigem.size}")
+    private String identidadeHostOrigem;
+    @Size(max = 50, message = "{identidadeDominioOrigem.size}")
+    private String identidadeDominioOrigem;
+    @Size(max = 7, message = "{descricaoResultadoFinal.size}")
+    private String descricaoResultadoFinal;
+    @Size(max = 4096, message = "{descricaoInformacoesAdicionais.size}")
+    private String descricaoInformacoesAdicionais;
+}

--- a/trilha-auditoria-client/src/main/java/br/gov/bnb/s533/client/service/TrilhaApiClientService.java
+++ b/trilha-auditoria-client/src/main/java/br/gov/bnb/s533/client/service/TrilhaApiClientService.java
@@ -1,0 +1,99 @@
+package br.gov.bnb.s533.client.service;
+
+import br.gov.bnb.s533.client.dto.ResultadoDTO;
+import br.gov.bnb.s533.client.dto.RetornoAuditoriaDTO;
+import br.gov.bnb.s533.client.dto.TrilhaDTO;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class TrilhaApiClientService {
+
+    private final RestTemplate trilhaApiRestTemplate;
+
+    public TrilhaApiClientService(RestTemplate trilhaApiRestTemplate) {
+        this.trilhaApiRestTemplate = trilhaApiRestTemplate;
+    }
+
+    public ResponseEntity<ResultadoDTO<TrilhaDTO>> enviarTrilha(TrilhaDTO request) {
+        Assert.notNull(request, "O corpo da requisição não pode ser nulo");
+        try {
+            return trilhaApiRestTemplate.exchange(
+                    "/api/v1/trilhas",
+                    HttpMethod.POST,
+                    new HttpEntity<>(request),
+                    new ParameterizedTypeReference<>() {}
+            );
+        } catch (RestClientResponseException ex) {
+            throw buildResponseStatusException(ex);
+        } catch (RestClientException ex) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Erro ao se comunicar com a Trilha API",
+                    ex
+            );
+        }
+    }
+
+    public ResponseEntity<ResultadoDTO<List<RetornoAuditoriaDTO>>> consultarTrilhas(
+            LocalDate dataInicio,
+            LocalDate dataFim,
+            String identidadeResponsavel,
+            String identidadeSistema,
+            int limit,
+            int offset
+    ) {
+        Assert.notNull(dataInicio, "A data inicial é obrigatória");
+        Assert.notNull(dataFim, "A data final é obrigatória");
+
+        URI uri = UriComponentsBuilder.fromPath("/api/v1/trilhas")
+                .queryParam("dataInicio", dataInicio)
+                .queryParam("dataFim", dataFim)
+                .queryParam("limit", limit)
+                .queryParam("offset", offset)
+                .queryParamIfPresent("identidadeResponsavel", Optional.ofNullable(identidadeResponsavel))
+                .queryParamIfPresent("identidadeSistema", Optional.ofNullable(identidadeSistema))
+                .build(true)
+                .toUri();
+
+        try {
+            return trilhaApiRestTemplate.exchange(
+                    uri,
+                    HttpMethod.GET,
+                    null,
+                    new ParameterizedTypeReference<>() {}
+            );
+        } catch (RestClientResponseException ex) {
+            throw buildResponseStatusException(ex);
+        } catch (RestClientException ex) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Erro ao se comunicar com a Trilha API",
+                    ex
+            );
+        }
+    }
+
+    private ResponseStatusException buildResponseStatusException(RestClientResponseException ex) {
+        HttpStatus status = HttpStatus.resolve(ex.getStatusCode().value());
+        if (status == null) {
+            status = HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+        return new ResponseStatusException(status, ex.getResponseBodyAsString(), ex);
+    }
+}

--- a/trilha-auditoria-client/src/main/resources/application.properties
+++ b/trilha-auditoria-client/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+spring.application.name=trilha-auditoria-client
+server.port=9090
+
+trilhaapi.client.base-url=http://localhost:8080
+
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html

--- a/trilha-auditoria-client/src/test/java/br/gov/bnb/s533/client/service/TrilhaApiClientServiceTest.java
+++ b/trilha-auditoria-client/src/test/java/br/gov/bnb/s533/client/service/TrilhaApiClientServiceTest.java
@@ -1,0 +1,149 @@
+package br.gov.bnb.s533.client.service;
+
+import br.gov.bnb.s533.client.dto.ResultadoDTO;
+import br.gov.bnb.s533.client.dto.RetornoAuditoriaDTO;
+import br.gov.bnb.s533.client.dto.TrilhaDTO;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.client.match.MockRestRequestMatchers;
+import org.springframework.test.web.client.response.MockRestResponseCreators;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TrilhaApiClientServiceTest {
+
+    private TrilhaApiClientService service;
+    private MockRestServiceServer server;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        this.objectMapper = new ObjectMapper();
+        this.objectMapper.registerModule(new JavaTimeModule());
+
+        RestTemplate restTemplate = new RestTemplateBuilder()
+                .rootUri("http://localhost:8080")
+                .additionalCustomizers(template -> template.getMessageConverters().stream()
+                        .filter(converter -> converter instanceof MappingJackson2HttpMessageConverter)
+                        .map(MappingJackson2HttpMessageConverter.class::cast)
+                        .forEach(converter -> converter.setObjectMapper(this.objectMapper)))
+                .build();
+        this.server = MockRestServiceServer.bindTo(restTemplate).build();
+        this.service = new TrilhaApiClientService(restTemplate);
+    }
+
+    @Test
+    void deveEnviarTrilhaComSucesso() throws JsonProcessingException {
+        TrilhaDTO trilhaDTO = TrilhaDTO.builder()
+                .identidadeTipoEvento(1)
+                .dataInicialEvento(LocalDateTime.of(2024, 1, 1, 10, 0))
+                .dataFinalEvento(LocalDateTime.of(2024, 1, 1, 10, 5))
+                .identidadeResponsavel("usuario.test")
+                .identidadeSistema("S533")
+                .build();
+
+        ResultadoDTO<TrilhaDTO> resultado = ResultadoDTO.<TrilhaDTO>builder()
+                .status(HttpStatus.CREATED.value())
+                .message("Trilha enviada para fila MQ")
+                .data(trilhaDTO)
+                .build();
+
+        server.expect(MockRestRequestMatchers.requestTo("http://localhost:8080/api/v1/trilhas"))
+                .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
+                .andExpect(MockRestRequestMatchers.content().contentType(MediaType.APPLICATION_JSON))
+                .andRespond(MockRestResponseCreators.withStatus(HttpStatus.CREATED)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(objectMapper.writeValueAsString(resultado)));
+
+        ResponseEntity<ResultadoDTO<TrilhaDTO>> resposta = service.enviarTrilha(trilhaDTO);
+
+        server.verify();
+        assertThat(resposta.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(resposta.getBody()).isNotNull();
+        assertThat(resposta.getBody().getMessage()).isEqualTo("Trilha enviada para fila MQ");
+    }
+
+    @Test
+    void deveConsultarTrilhasComSucesso() throws JsonProcessingException {
+        LocalDate dataInicio = LocalDate.of(2024, 1, 1);
+        LocalDate dataFim = LocalDate.of(2024, 1, 10);
+
+        List<RetornoAuditoriaDTO> dados = List.of(
+                new RetornoAuditoriaDTO(
+                        10,
+                        LocalDateTime.of(2024, 1, 1, 10, 0),
+                        LocalDateTime.of(2024, 1, 1, 10, 5),
+                        "usuario.test",
+                        "S533",
+                        "MOD",
+                        "Consulta",
+                        "127.0.0.1",
+                        "localhost",
+                        "bnb.gov",
+                        1,
+                        "Consulta"
+                )
+        );
+
+        ResultadoDTO<List<RetornoAuditoriaDTO>> resultado = ResultadoDTO.<List<RetornoAuditoriaDTO>>builder()
+                .status(HttpStatus.OK.value())
+                .message("Resultado da consulta")
+                .data(dados)
+                .build();
+
+        server.expect(MockRestRequestMatchers.requestTo("http://localhost:8080/api/v1/trilhas?dataInicio=2024-01-01&dataFim=2024-01-10&limit=10&offset=0"))
+                .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
+                .andRespond(MockRestResponseCreators.withSuccess(objectMapper.writeValueAsString(resultado), MediaType.APPLICATION_JSON));
+
+        ResponseEntity<ResultadoDTO<List<RetornoAuditoriaDTO>>> resposta = service.consultarTrilhas(
+                dataInicio,
+                dataFim,
+                null,
+                null,
+                10,
+                0
+        );
+
+        server.verify();
+        assertThat(resposta.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(resposta.getBody()).isNotNull();
+        assertThat(resposta.getBody().getData()).hasSize(1);
+    }
+
+    @Test
+    void devePropagarErroQuandoApiRetornaFalha() {
+        TrilhaDTO trilhaDTO = TrilhaDTO.builder()
+                .identidadeTipoEvento(1)
+                .dataInicialEvento(LocalDateTime.of(2024, 1, 1, 10, 0))
+                .dataFinalEvento(LocalDateTime.of(2024, 1, 1, 10, 5))
+                .build();
+
+        server.expect(MockRestRequestMatchers.requestTo("http://localhost:8080/api/v1/trilhas"))
+                .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
+                .andRespond(MockRestResponseCreators.withStatus(HttpStatus.BAD_REQUEST)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"message\":\"Dados inválidos\"}"));
+
+        assertThatThrownBy(() -> service.enviarTrilha(trilhaDTO))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(throwable -> assertThat(((ResponseStatusException) throwable).getStatusCode())
+                        .isEqualTo(HttpStatus.BAD_REQUEST));
+    }
+}


### PR DESCRIPTION
## Summary
- remove the embedded Trilha client from the serviço project and document the new setup in the main README
- add a new standalone Spring Boot application under `trilha-auditoria-client` that proxies Trilha Auditoria Serviço endpoints
- include DTOs, configuration, REST controller, and unit tests to simulate publish/consult flows against the remote API

## Testing
- mvn -q test *(fails: unable to resolve org.springframework.boot:spring-boot-starter-parent:pom:3.4.4 due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68debd218da48328861a87a0ff36696e